### PR TITLE
Fix README instructions for repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Desenvolvido com **Node.js (Express)**, **MySQL** e um **frontend HTML + Bootstr
 
 ```bash
 git clone https://github.com/Luizinz00/gestor-de-multas
-cd gestor_multas
+cd gestor-de-multas
 ```
 
 ---


### PR DESCRIPTION
## Summary
- correct folder name in README cloning instructions

## Testing
- `npm test` *(fails: Missing script: "test" and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b27fc418c8331b3266f7192b3f0c7